### PR TITLE
Do not include search terms in topic nodes from kolibri URLs

### DIFF
--- a/src/kolibri_gnome/kolibri_context.py
+++ b/src/kolibri_gnome/kolibri_context.py
@@ -169,7 +169,10 @@ class KolibriContext(GObject.GObject):
         if node_type == "c":
             return self._get_kolibri_content_path(node_id, url_search)
         elif node_type == "t":
-            return self._get_kolibri_topic_path(node_id, url_search)
+            # As a special case, don't include the search property for topic
+            # nodes. This means Kolibri will always show a simple browsing
+            # interface for a topic, instead of a search interface.
+            return self._get_kolibri_topic_path(node_id, None)
         else:
             return self._get_kolibri_library_path(url_search)
 


### PR DESCRIPTION
In Kolibri 0.15, if a URL for a topic node includes search terms,
Kolibri displays a search interface in that context. When the user
selects a topic node from the GNOME Shell search provider, we would like
to simply display the topic node instead of a search interface.

https://phabricator.endlessm.com/T33310