### PR TITLE
Use a smaller cherrypy thread pool by default

### DIFF
--- a/data/metainfo/org.learningequality.Kolibri.metainfo.xml.in.in
+++ b/data/metainfo/org.learningequality.Kolibri.metainfo.xml.in.in
@@ -28,6 +28,7 @@
         <ul>
           <li>Kolibri is updated to version 0.15.0.</li>
           <li>The application runtime is updated to GNOME 41.</li>
+          <li>Use a smaller number of cherrypy threads by default.</li>
         </ul>
       </description>
     </release>

--- a/src/kolibri_daemon/kolibri_utils.py
+++ b/src/kolibri_daemon/kolibri_utils.py
@@ -54,6 +54,11 @@ def init_kolibri(**kwargs):
 def _init_kolibri_env():
     os.environ["DJANGO_SETTINGS_MODULE"] = "kolibri_app.kolibri_settings"
 
+    # Kolibri defaults to a very large thread pool. Because we expect this
+    # application to be used in a single user environment with a limited
+    # workload, we can use a smaller number of threads.
+    os.environ.setdefault("KOLIBRI_CHERRYPY_THREAD_POOL", "10")
+
     # Automatically provision with $KOLIBRI_HOME/automatic_provision.json if it
     # exists.
     # TODO: Once kolibri-gnome supports automatic login for all cases, use an


### PR DESCRIPTION
It is possible to override this with the KOLIBRI_CHERRYPY_THREAD_POOL
environment variable.

https://phabricator.endlessm.com/T33329