### PR TITLE
T34443 collections plugin file export

### DIFF
--- a/build-aux/flatpak/modules/kolibri-plugins-dir.json
+++ b/build-aux/flatpak/modules/kolibri-plugins-dir.json
@@ -1,0 +1,7 @@
+{
+    "name" : "kolibri-plugins-dir",
+    "buildsystem" : "simple",
+    "build-commands" : [
+        "install -d -m 755 ${FLATPAK_DEST}/kolibri-plugins"
+    ]
+}

--- a/build-aux/flatpak/org.learningequality.Kolibri.Devel.json
+++ b/build-aux/flatpak/org.learningequality.Kolibri.Devel.json
@@ -16,12 +16,20 @@
         "--system-talk-name=org.learningequality.Kolibri.Devel.Daemon",
         "--env=KOLIBRI_HOME=~/.var/app/org.learningequality.Kolibri.Devel/data/kolibri",
         "--env=KOLIBRI_HTTP_PORT=0",
-        "--env=KOLIBRI_STATIC_USE_SYMLINKS=0"
+        "--env=KOLIBRI_STATIC_USE_SYMLINKS=0",
+        "--env=PYTHONPATH=/app/kolibri-plugins/lib/python"
     ],
     "add-extensions" : {
         "org.learningequality.Kolibri.Content" : {
             "version" : "1.0",
             "directory" : "share/kolibri-content",
+            "subdirectories" : true,
+            "no-autodownload" : true
+        },
+        "org.learningequality.Kolibri.Plugin" : {
+            "version" : "1.0",
+            "directory" : "kolibri-plugins",
+            "merge-dirs": "lib/python",
             "subdirectories" : true,
             "no-autodownload" : true
         }
@@ -45,6 +53,7 @@
         "modules/python3-setproctitle.json",
         "modules/python3-virtualenv-api.json",
         "modules/kolibri-content-dir.json",
+        "modules/kolibri-plugins-dir.json",
         {
             "name" : "kolibri-gnome",
             "buildsystem" : "meson",

--- a/src/kolibri_gnome/application.py
+++ b/src/kolibri_gnome/application.py
@@ -136,8 +136,8 @@ class Application(Gtk.Application):
 
         window = KolibriWindow(application=self, context=self.__context, **kwargs)
 
+        window.connect("open-in-browser", self.__window_on_open_in_browser)
         window.connect("open-new-window", self.__window_on_open_new_window)
-        window.connect("external-url", self.__window_on_external_url)
 
         # Set WM_CLASS for improved window management
         # FIXME: GTK+ strongly discourages doing this:
@@ -193,6 +193,9 @@ class Application(Gtk.Application):
     ):
         self.open_url_in_external_application(external_url)
 
+    def __window_on_open_in_browser(self, window: KolibriWindow, current_url: str):
+        self.open_url_in_external_application(current_url)
+
     def __window_on_open_new_window(
         self, window: KolibriWindow, target_url: str, related_webview: WebKit2.WebView
     ) -> typing.Optional[KolibriWebView]:
@@ -200,9 +203,6 @@ class Application(Gtk.Application):
             target_url, related_webview=related_webview
         )
         return new_window.get_main_webview() if new_window else None
-
-    def __window_on_external_url(self, window: KolibriWindow, external_url: str):
-        self.open_url_in_external_application(external_url)
 
     def __handle_open_file_url(self, url: str):
         valid_url_schemes = ("kolibri", "x-kolibri-app")

--- a/src/kolibri_gnome/application.py
+++ b/src/kolibri_gnome/application.py
@@ -33,6 +33,7 @@ class Application(Gtk.Application):
 
         self.__context = context or KolibriContext()
         self.__context.connect("download-started", self.__context_on_download_started)
+        self.__context.connect("open-external-url", self.__context_on_open_external_url)
 
         action = Gio.SimpleAction.new("open-documentation", None)
         action.connect("activate", self.__on_open_documentation)
@@ -186,6 +187,11 @@ class Application(Gtk.Application):
         download.set_allow_overwrite(True)
         download.set_destination(file_chooser.get_uri())
         return True
+
+    def __context_on_open_external_url(
+        self, context: KolibriContext, external_url: str
+    ):
+        self.open_url_in_external_application(external_url)
 
     def __window_on_open_new_window(
         self, window: KolibriWindow, target_url: str, related_webview: WebKit2.WebView

--- a/src/kolibri_gnome/application.py
+++ b/src/kolibri_gnome/application.py
@@ -128,7 +128,7 @@ class Application(Gtk.Application):
     ) -> typing.Optional[KolibriWindow]:
         target_url = target_url or self.__context.default_url
 
-        if not self.__context.should_load_url(target_url):
+        if not self.__context.should_open_url(target_url):
             self.open_url_in_external_application(target_url)
             return None
 

--- a/src/kolibri_gnome/application.py
+++ b/src/kolibri_gnome/application.py
@@ -32,6 +32,7 @@ class Application(Gtk.Application):
         super().__init__(*args, flags=Gio.ApplicationFlags.HANDLES_OPEN, **kwargs)
 
         self.__context = context or KolibriContext()
+        self.__context.connect("download-started", self.__context_on_download_started)
 
         action = Gio.SimpleAction.new("open-documentation", None)
         action.connect("activate", self.__on_open_documentation)
@@ -154,6 +155,37 @@ class Application(Gtk.Application):
         window.show()
 
         return window
+
+    def __context_on_download_started(
+        self, context: KolibriContext, download: WebKit2.Download
+    ):
+        download.connect("decide-destination", self.__download_on_decide_destination)
+
+    def __download_on_decide_destination(
+        self, download: WebKit2.Download, suggested_filename: str
+    ) -> bool:
+        file_chooser = Gtk.FileChooserNative.new(
+            _("Save File"),
+            self.get_active_window(),
+            Gtk.FileChooserAction.SAVE,
+            None,
+            None,
+        )
+        file_chooser.set_current_name(suggested_filename)
+        file_chooser.set_do_overwrite_confirmation(True)
+
+        # We need to block on the dialog here because webkit will be unhappy if
+        # we return before setting a destination.
+
+        response = file_chooser.run()
+
+        if response != Gtk.ResponseType.ACCEPT:
+            download.cancel()
+            return False
+
+        download.set_allow_overwrite(True)
+        download.set_destination(file_chooser.get_uri())
+        return True
 
     def __window_on_open_new_window(
         self, window: KolibriWindow, target_url: str, related_webview: WebKit2.WebView

--- a/src/kolibri_gnome/kolibri_context.py
+++ b/src/kolibri_gnome/kolibri_context.py
@@ -48,6 +48,7 @@ class KolibriContext(GObject.GObject):
     session_status = GObject.Property(type=int, default=SESSION_STATUS_LOADING)
 
     __gsignals__ = {
+        "download-started": (GObject.SIGNAL_RUN_FIRST, None, (WebKit2.Download,)),
         "kolibri-ready": (GObject.SIGNAL_RUN_FIRST, None, ()),
     }
 
@@ -76,6 +77,11 @@ class KolibriContext(GObject.GObject):
         self.__webkit_web_context = WebKit2.WebContext(
             website_data_manager=website_data_manager
         )
+
+        self.__webkit_web_context.connect(
+            "download-started", self.__webkit_web_context_on_download_started
+        )
+
         self.__kolibri_daemon = KolibriDaemonManager()
         self.__setup_helper = _KolibriSetupHelper(
             self.__webkit_web_context, self.__kolibri_daemon
@@ -210,6 +216,13 @@ class KolibriContext(GObject.GObject):
         - x-kolibri-app:/device
         """
         return url_tuple._replace(scheme="", netloc="").geturl()
+
+    def __webkit_web_context_on_download_started(
+        self, webkit_web_context: WebKit2.WebContext, download: WebKit2.Download
+    ):
+        url = download.get_request().get_uri()
+
+        self.emit("download-started", download)
 
     def __update_session_status(self, has_error: bool, is_setup_complete: bool):
         if has_error:

--- a/src/kolibri_gnome/kolibri_context.py
+++ b/src/kolibri_gnome/kolibri_context.py
@@ -49,6 +49,7 @@ class KolibriContext(GObject.GObject):
 
     __gsignals__ = {
         "download-started": (GObject.SIGNAL_RUN_FIRST, None, (WebKit2.Download,)),
+        "open-external-url": (GObject.SIGNAL_RUN_FIRST, None, (str,)),
         "kolibri-ready": (GObject.SIGNAL_RUN_FIRST, None, ()),
     }
 
@@ -222,7 +223,23 @@ class KolibriContext(GObject.GObject):
     ):
         url = download.get_request().get_uri()
 
+        # If the URL will open in the default Kolibri app (it is only external
+        # for this context), translate it to a x-kolibri-app URL.
+        if self.default_is_url_in_scope(url):
+            url = self.url_to_x_kolibri_app(url)
+
+        if self.__should_open_url_in_external_application(url):
+            download.cancel()
+            self.emit("open-external-url", url)
+            return
+
         self.emit("download-started", download)
+
+    def __should_open_url_in_external_application(self, url):
+        # We need to download blob URLs because they are unique to this context,
+        # but otherwise we will expect that a local application can handle the
+        # same protocol.
+        return urlsplit(url).scheme not in ("blob",)
 
     def __update_session_status(self, has_error: bool, is_setup_complete: bool):
         if has_error:

--- a/src/kolibri_gnome/kolibri_context.py
+++ b/src/kolibri_gnome/kolibri_context.py
@@ -119,7 +119,7 @@ class KolibriContext(GObject.GObject):
     def kolibri_api_get_async(self, *args, **kwargs):
         self.__kolibri_daemon.kolibri_api_get_async(*args, **kwargs)
 
-    def should_load_url(self, url: str) -> bool:
+    def should_open_url(self, url: str) -> bool:
         return (
             url == self.default_url
             or urlsplit(url).scheme in ("kolibri", "x-kolibri-app", "about")

--- a/src/kolibri_gnome/kolibri_webview.py
+++ b/src/kolibri_gnome/kolibri_webview.py
@@ -81,24 +81,26 @@ class KolibriWebView(WebKit2.WebView):
     ):
         if decision_type == WebKit2.PolicyDecisionType.NAVIGATION_ACTION:
             target_url = decision.get_request().get_uri()
-            if not self.__context.should_load_url(target_url):
+            if self.__context.should_open_url(target_url):
+                return False
+            else:
                 decision.ignore()
                 self.__emit_external_url(target_url)
                 return True
         return False
 
     def __on_notify_uri(self, webview: WebKit2.WebView, pspec: GObject.ParamSpec):
-        # PEWApp.should_load_url is not called when the URL fragment changes.
-        # So, when the uri property changes, we may want to check if the URL
-        # (including URL fragment) refers to content which belongs inside the
-        # window.
+        # KolibriContext.should_open_url is not called when the URL fragment
+        # changes. So, when the URI property changes, we may want to check if
+        # the URL (including URL fragment) refers to content which belongs
+        # inside the window.
 
         target_url = webview.get_uri()
 
         if not target_url:
             return
 
-        if self.__context.should_load_url(target_url):
+        if self.__context.should_open_url(target_url):
             return
 
         # It would be nice if we could remove the not allowed items from the
@@ -130,14 +132,14 @@ class KolibriWebView(WebKit2.WebView):
     def __get_allowed_back_item(self, webview: WebKit2.WebView):
         for back_item in webview.get_back_forward_list().get_back_list():
             back_uri = back_item.get_uri()
-            if back_uri and self.__context.should_load_url(back_uri):
+            if back_uri and self.__context.should_open_url(back_uri):
                 return back_item
         return None
 
     def __context_on_kolibri_ready(self, context: KolibriContext):
         if self.__deferred_load_kolibri_url:
             self.__continue_load_kolibri_url()
-        elif not self.__context.should_load_url(self.get_uri()):
+        elif not self.__context.should_open_url(self.get_uri()):
             self.load_kolibri_url(self.__context.default_url)
         else:
             self.emit("kolibri-load-finished")

--- a/src/kolibri_gnome/kolibri_window.py
+++ b/src/kolibri_gnome/kolibri_window.py
@@ -31,6 +31,7 @@ class KolibriWindow(Gtk.ApplicationWindow):
     __present_on_main_webview_ready: bool = True
 
     __gsignals__ = {
+        "open-in-browser": (GObject.SIGNAL_RUN_FIRST, None, (str,)),
         "open-new-window": (
             GObject.SIGNAL_RUN_FIRST,
             KolibriWebView,
@@ -39,7 +40,6 @@ class KolibriWindow(Gtk.ApplicationWindow):
                 WebKit2.WebView,
             ),
         ),
-        "external-url": (GObject.SIGNAL_RUN_FIRST, None, (str,)),
     }
 
     def __init__(
@@ -139,7 +139,6 @@ class KolibriWindow(Gtk.ApplicationWindow):
         self.__header_bar.show_all()
 
         bubble_signal(self.__webview_stack, "open-new-window", self)
-        bubble_signal(self.__webview_stack, "external-url", self)
 
         self.__webview_stack.connect(
             "main-webview-ready", self.__webview_stack_on_main_webview_ready
@@ -215,7 +214,7 @@ class KolibriWindow(Gtk.ApplicationWindow):
     def __on_open_in_browser(self, action, *args):
         url = self.__webview_stack.get_uri()
         if url:
-            self.emit("external-url", url)
+            self.emit("open-in-browser", url)
 
     def __on_navigate_back(self, action, *args):
         self.__webview_stack.go_back()


### PR DESCRIPTION
This change adds a handler for the [`download-started`](https://webkitgtk.org/reference/webkit2gtk/stable/signal.WebContext.download-started.html) signal in KolibriContext's WebKit web context. With that change, we can move a bunch of logic related to opening files in an external application out of `KolibriWebView` and over to `KolibriContext`. Most importantly, that code understands that `blob` URIs are special and can't be opened by external applications. Instead, they must be saved to disk by using WebKit's download mechanism.

https://phabricator.endlessm.com/T34443